### PR TITLE
Open sphinx-design tabs with a URL query

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -98,7 +98,6 @@ html_title = project
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = ['theme_overrides.css']
-html_css_files = ["theme_overrides.css"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/source/user-guide/mount-connect.rst
+++ b/source/user-guide/mount-connect.rst
@@ -34,9 +34,11 @@ More information on the best location to mount the commutator is available on th
 Connecting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. tab-set::
+..  tab-set::
+    :sync-group: commutator
 
-    .. tab-item:: Coax Commutator
+    ..  tab-item:: Coax Commutator
+        :sync: coax
 
         ..  grid:: 
             :margin: 0
@@ -71,7 +73,8 @@ Connecting
 
                 ..  image:: /_static/images/connections-numbered.png
 
-    .. tab-item:: SPI Commutator
+    ..  tab-item:: SPI Commutator
+        :sync: spi
 
         ..  grid:: 
             :margin: 0


### PR DESCRIPTION
For example:
- `https://open-ephys.github.io/commutator-docs/docs/user-guide/mount-connect.html?commutator=coax#connecting`
- `https://open-ephys.github.io/commutator-docs/docs/user-guide/mount-connect.html?commutator=spi#connecting`