### PR TITLE
Fix broken links and add overview table with SLEAP and DLC versions, frameworks, and Bonsai Support

### DIFF
--- a/source/_static/files/SLEAP-DLC-Bonsai-diff.csv
+++ b/source/_static/files/SLEAP-DLC-Bonsai-diff.csv
@@ -1,0 +1,10 @@
+**Pose Estimation Algorithm**,Version,Framework,Models and configuration/files format,Bonsai support for real-time pose estimation,Documentation
+**SLEAP**,< v1.5,TensorFlow,".pb
+.json",Yes. Bonsai.SLEAP (version 0.3.0),"https://bonsai-rx.org/sleap/index.html
+https://legacy.sleap.ai/guides/bonsai.html"
+**SLEAP**,≥ v1.5,Torch,"Torch checkpoints .pt
+.yaml","Not yet, but on the `radar <https://github.com/bonsai-rx/sleap/issues/34>`_",
+**Deep Lab Cut**,< v3.0,TensorFlow,".pb
+.yaml",Yes. Bonsai.DeepLabCut (version 0.3.0),https://bonsai-rx.org/deeplabcut/
+**Deep Lab Cut**,≥ v3.0,Torch,"Torch checkpoints .pt
+.yaml",Not yet.,

--- a/source/_static/files/SLEAP-DLC-Bonsai-diff.csv
+++ b/source/_static/files/SLEAP-DLC-Bonsai-diff.csv
@@ -1,10 +1,10 @@
 **Pose Estimation Algorithm**,Version,Framework,Models and configuration/files format,Bonsai support for real-time pose estimation,Documentation
-**SLEAP**,< v1.5,TensorFlow,".pb
-.json",Yes. Bonsai.SLEAP (version 0.3.0),"https://bonsai-rx.org/sleap/index.html
-https://legacy.sleap.ai/guides/bonsai.html"
-**SLEAP**,≥ v1.5,Torch,"Torch checkpoints .pt
-.yaml","Not yet, but on the `radar <https://github.com/bonsai-rx/sleap/issues/34>`_",
-**Deep Lab Cut**,< v3.0,TensorFlow,".pb
-.yaml",Yes. Bonsai.DeepLabCut (version 0.3.0),https://bonsai-rx.org/deeplabcut/
-**Deep Lab Cut**,≥ v3.0,Torch,"Torch checkpoints .pt
-.yaml",Not yet.,
+**SLEAP**,< v1.5,TensorFlow,"| .pb
+| .json",Yes. Bonsai.SLEAP (version 0.3.0),"| https://bonsai-rx.org/sleap/index.html
+| https://legacy.sleap.ai/guides/bonsai.html"
+**SLEAP**,≥ v1.5,Torch,"| Torch checkpoints .pt
+| .yaml","Not yet, but on the `radar <https://github.com/bonsai-rx/sleap/issues/34>`_",
+**Deep Lab Cut**,< v3.0,TensorFlow,"| .pb
+| .yaml",Yes. Bonsai.DeepLabCut (version 0.3.0),https://bonsai-rx.org/deeplabcut/
+**Deep Lab Cut**,≥ v3.0,Torch,"| Torch checkpoints .pt
+| .yaml",Not yet.,

--- a/source/user-guide/automatic-control/computer-vision.rst
+++ b/source/user-guide/automatic-control/computer-vision.rst
@@ -32,10 +32,10 @@ moving animal. This example uses SLEAP.
 #.  Prepare your network model for automating commutation:
 
     #.  Follow `these instructions to train a network model
-        <https://docs.sleap.ai/latest/tutorial/initial-labeling.html>`_ if you do not already have one.
+        <https://docs.sleap.ai/latest/tutorial/initial-labeling/>`_ if you do not already have one.
 
     #.  Follow `these instructions to configure your trained network
-        <https://docs.sleap.ai/latest/learnings/configuring-models.html>`_.
+        <https://docs.sleap.ai/latest/learnings/configuring-models/>`_.
     
     #.  Take a snapshot of your behavioral arena with no animal inside which will serve as the background.
 

--- a/source/user-guide/automatic-control/computer-vision.rst
+++ b/source/user-guide/automatic-control/computer-vision.rst
@@ -85,3 +85,14 @@ moving animal. This example uses SLEAP.
         commutator is connected.
 
 #. Run the workflow in Bonsai. If all above steps are correctly performed, the commutator will follow rotations.
+
+SLEAP and DeepLabCut versions and Bonsai Compatibility
+------------------------------------------------------
+
+Machine learning frameworks have recently migrated from TensorFlow to Torch, and while older versions of both SLEAP and DLC were supported in Bonsai, newer Torch models don’t yet have standalone packages. You can still use older TensorFlow models with the older Bonsai packages, as per the table below.
+
+.. csv-table:: 
+   :file: /_static/files/SLEAP-DLC-Bonsai-diff.csv
+   :widths: 30, 30, 30, 30, 30, 30
+   :header-rows: 1
+   :stub-columns: 1

--- a/source/user-guide/automatic-control/computer-vision.rst
+++ b/source/user-guide/automatic-control/computer-vision.rst
@@ -32,10 +32,10 @@ moving animal. This example uses SLEAP.
 #.  Prepare your network model for automating commutation:
 
     #.  Follow `these instructions to train a network model
-        <https://sleap.ai/develop/tutorials/initial-labeling.html>`_ if you do not already have one.
+        <https://docs.sleap.ai/latest/tutorial/initial-labeling.html>`_ if you do not already have one.
 
     #.  Follow `these instructions to configure your trained network
-        <https://sleap.ai/develop/guides/choosing-models.html>`_.
+        <https://docs.sleap.ai/latest/learnings/configuring-models.html>`_.
     
     #.  Take a snapshot of your behavioral arena with no animal inside which will serve as the background.
 


### PR DESCRIPTION
Added an overview table with SLEAP and DLC versions and frameworks, and their Bonsai support/compatibility - versions, frameworks, file formats, Bonsai packages and useful docs.

Fix broken links in guide to prepare network model for automating commutation (with SLEAP).

@cjsha could you please check if the second link is the correct one?

Fix #53 
Fix #52 