### PR TITLE
list card headings in side menu

### DIFF
--- a/source/user-guide/automatic-control/index.rst
+++ b/source/user-guide/automatic-control/index.rst
@@ -20,4 +20,8 @@ Using Computer Vision
 .. toctree::
     :hidden:
 
+    Acquisition Board in OE GUI <https://open-ephys.github.io/gui-docs/Tutorials/Commutator.html?acquisition-hardware=acquisition-board>
+    ONIX in OE GUI <https://open-ephys.github.io/gui-docs/Tutorials/Commutator.html?acquisition-hardware=onix>
+    ONIX in Bonsai <https://open-ephys.github.io/bonsai-onix1-docs/articles/hardware/index.html>    
+    Miniscope DAQ in Bonsai <https://open-ephys.github.io/miniscope-docs/ucla-miniscope-v4/user/miniscope-daq/commutate/index.html>
     computer-vision


### PR DESCRIPTION
As it was previously, only the commutate with computer vision heading was visible, making it seem like there were no other sections. I think cards should be treated like sections, or we should give all cards a title "commutate with 3D capable headstages" and link to the section.